### PR TITLE
Redirect stdio properly in `og run`

### DIFF
--- a/build.go
+++ b/build.go
@@ -166,10 +166,12 @@ func (o *Og) RunBuild(steps []*BuildStep) error {
 			for _, line := range step.Cmds {
 				cmd := exec.Command("sh", "-c", line)
 				cmd.Env = env
-				out, err := cmd.CombinedOutput()
-				out = bytes.TrimSpace(out)
-				if len(out) > 0 {
-					fmt.Printf("%s\n", out)
+				cmd.Stdin = os.Stdin
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				err := cmd.Run();
+				if err != nil {
+					log.Fatal(err)
 				}
 				if err != nil && !strings.HasPrefix(line, "mkdir") {
 					log.Fatal(err)


### PR DESCRIPTION
Old behavior: `og run foo.go` doesn't write any output until foo.go terminates.
New behavior matches `go run`
